### PR TITLE
version: bump to 0.0.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description = DVC render
 name = dvc-render
-version = 0.0.4
+version = 0.0.5
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = Apache-2.0


### PR DESCRIPTION
Seems like lack of bump was the reason of failing release build.
https://github.com/iterative/dvc-render/actions/runs/2226819138