### PR TITLE
vega: templates: make confusion matrix interactive

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -176,6 +176,34 @@ class ConfusionTemplate(Template):
                     },
                 },
                 {
+                    "selection": {
+                        "label": {
+                            "type": "single",
+                            "on": "mouseover",
+                            "encodings": ["x", "y"],
+                            "empty": "none",
+                            "clear": "mouseout",
+                        }
+                    },
+                    "mark": "rect",
+                    "encoding": {
+                        "tooltip": [
+                            {"field": "actual", "type": "nominal"},
+                            {"field": "predicted", "type": "nominal"},
+                        ],
+                        "opacity": {
+                            "condition": {"selection": "label", "value": 1},
+                            "value": 0,
+                        },
+                    },
+                },
+                {
+                    "transform": [{"filter": {"selection": "label"}}],
+                    "layer": [
+                        {"mark": {"type": "rect", "color": "lightpink"}},
+                    ],
+                },
+                {
                     "mark": "text",
                     "encoding": {
                         "text": {"field": "xy_count", "type": "quantitative"},
@@ -256,6 +284,34 @@ class NormalizedConfusionTemplate(Template):
                             "scale": {"domain": [0, 1]},
                         }
                     },
+                },
+                {
+                    "selection": {
+                        "label": {
+                            "type": "single",
+                            "on": "mouseover",
+                            "encodings": ["x", "y"],
+                            "empty": "none",
+                            "clear": "mouseout",
+                        }
+                    },
+                    "mark": "rect",
+                    "encoding": {
+                        "tooltip": [
+                            {"field": "actual", "type": "nominal"},
+                            {"field": "predicted", "type": "nominal"},
+                        ],
+                        "opacity": {
+                            "condition": {"selection": "label", "value": 1},
+                            "value": 0,
+                        },
+                    },
+                },
+                {
+                    "transform": [{"filter": {"selection": "label"}}],
+                    "layer": [
+                        {"mark": {"type": "rect", "color": "lightpink"}},
+                    ],
                 },
                 {
                     "mark": "text",


### PR DESCRIPTION
Introducing interactivity to confusion matrix.
[example](https://vega.github.io/editor/#/url/vega-lite/N4IgJAzgxgFgpgWwIYgFwhgF0wBwqgegIDc4BzJAOjIEtMYBXAI0poHsDp5kTykBaADZ04JACyUAVhDYA7EABoQAEySYUqUMSSCGcCGgDaoJFEwMdaEFEFIIEAPoBGRSABmNQXFlIEcK1ByblIy8ko4AE5wyjRm0QG29s6uUcRWAO5sEQDWEDimcKiogbLB0nIgAL4KJmYWggl2ji5KHl4+fgFBIRXhUTFxyo1JLSCpGVm5+VCFxd3l8tW15pboNk3JrZ7evv5r86GukdGxmPFriY4ATClwaeiZOXkFRSVlh0sgpisNFxs3W3auy6pR6YRAxwGZyGfxGt3uIEeUxec1BCyqNS+dVW1kuDgB7m2HT21gOvQh-VO51x-3hEye01mbzBGOW9WGzVcbR2nX2aMOfROgw5+Lp6AAEgBRACCABFXmTFpjvuzYZzATyScz0YKodT1kkCeMJTL5aj3hVPiqcQb1YSgbzSfzyZCqTCaYaxSApXKFc6lWybXiCdziSCLeDXcK1ZsxncrD6zdqPsrsb8PdcuUTgXyI0dKdGM7Hjd7TX685UALrVECYOheKzKYhQSgAT18gnLLNaBUwaFAHjggnd4yUmFbOBJsjYCBoPgaNbycCg-drESQsggbiyCCMJjIZCiFDOe5AbBwXQYsj7SjsVgAHq2HIEr32q0pD2wGDgmK2jBShWhVxrQaatMRoBAcAYE90EfZ8v2vVxP2-X9-1HAC9SGSslGyOA-3QEDXG0XQ9gABk+CCoJgkA4JfRCPwiL8f3www4zSW80xAbCQFw-CMLdIidD0NByMxSQ2DnJADyPNQ9mMM8L3QZB7yzId3VohCby+AwlKQe94NfKpuOQ5i0PjMDQCgHQoAYWxqNUcwEEoDTXwAAgIVyHIYJzlIM+jtKsScIhma8HDYNwHGUoylG8QIYlkMhVxUzRCTUqxCLHCcpxnSSGiUGQIj7AjoG8eLErHesSUImt8IHGg0vQKMgMyycrGnWd51cAqiu0kKytcOtMAbRqCyAyoa1sVs4AiU9kByKwojMVx0hoZR6DQABmUjSKUeAaDILBNu2mLZDiudEpSwJBCyVdB2HB8nzorTx1a9AAEcLGvOg1BoUgBsqqwuqs4bQGUGckDnABZOcRKUWRYj2TAIj0cbxsxCAh2XOsKhS2wmCHVcXpJCBzobJQcZABAvwxthSBmk6zoSnTWJUpQ-24xAcHHNq5H8JQbDgJAZqU6m4C-N8azm7IFqx1xYrYfqUvPUw6Fqp0Ymx+QUoxrwzHYLWQDxgmlGI4TUCcGtTbI1HMSRjctx3U82jOYXQB1rH9asI2F3fQ2kCm4X5Klwmsplpb+bYa7hcN-asBwOdpfGizKaF6X0DOe8tPlxXQAzoq6oamjHs0gbQ-ez7Bp+v6ayum7LrkDXPZSs4IB6rynKCkLMDCiLlNcgA+VzSMoABWQSSIyGARAxEArasJhbCgROk-GoA)
(hover over confusion matrix to see the effect).

Ideally we would also like to have ability to see number of actual vs number of predicted when hovering over it.
I will play around with this PR and see how hard that can be. If i wont find quick solution, I will create issue for that.


