### PR TITLE
confusion matrix: fix hardcoded values

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -188,8 +188,8 @@ class ConfusionTemplate(Template):
                     "mark": "rect",
                     "encoding": {
                         "tooltip": [
-                            {"field": "actual", "type": "nominal"},
-                            {"field": "predicted", "type": "nominal"},
+                            {"field": Template.anchor("x"), "type": "nominal"},
+                            {"field": Template.anchor("y"), "type": "nominal"},
                         ],
                         "opacity": {
                             "condition": {"selection": "label", "value": 1},
@@ -298,8 +298,8 @@ class NormalizedConfusionTemplate(Template):
                     "mark": "rect",
                     "encoding": {
                         "tooltip": [
-                            {"field": "actual", "type": "nominal"},
-                            {"field": "predicted", "type": "nominal"},
+                            {"field": Template.anchor("x"), "type": "nominal"},
+                            {"field": Template.anchor("y"), "type": "nominal"},
                         ],
                         "opacity": {
                             "condition": {"selection": "label", "value": 1},


### PR DESCRIPTION
In previous change (#45) I hardcoded the fields name. Fixing it here