### PR TITLE
cruft updates: force nox color, single workflow run and setuptools_scm for versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,17 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,13 @@ name: Tests
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: "1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     timeout-minutes: 10
@@ -15,6 +22,8 @@ jobs:
     steps:
     - name: Check out the repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.pyv }}
       uses: actions/setup-python@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ["setuptools>=48", "wheel"]
+requires = ["setuptools>=48", "setuptools_scm[toml]>=6.3.1"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 description = DVC render
 name = dvc-render
-version = 0.0.5
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = Apache-2.0


### PR DESCRIPTION
See https://github.com/iterative/py-template/pull/17.

I haven't bumped the cruft commit because there are some changes that are related to docs, which I was not sure how to fix.