### PR TITLE
Upgrade vega-lite to 5.2.0

### DIFF
--- a/src/dvc_render/vega.py
+++ b/src/dvc_render/vega.py
@@ -26,7 +26,7 @@ class VegaRenderer(Renderer):
 
     SCRIPTS = """
     <script src="https://cdn.jsdelivr.net/npm/vega@5.20.2"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.1.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.2.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.18.2"></script>
     """
 


### PR DESCRIPTION
Hello,

I wanted to create bar-plots for DVC and to be able to diff these I use the xOffset parameter in vega-lite. This was added in the 5.2.0 release of vega-lite.

For an example of the bar plots, see: https://github.com/daniel-falk/dvc-examples

I am not sure how to build DVC with this updated version of dvc-render, so I have not tested it other than with the custom html template in the repo linked above.