### PR TITLE
Bar chart template

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -111,6 +111,63 @@ class SimpleLinearTemplate(Template):
     }
 
 
+class BarHorizontalOrderedTemplate(Template):
+    DEFAULT_NAME = "bar_horizontal_ordered"
+
+    DEFAULT_CONTENT = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "data": {"values": Template.anchor("data")},
+        "title": Template.anchor("title"),
+        "width": 300,
+        "height": 300,
+        "mark": {"type": "bar"},
+        "encoding": {
+            "x": {
+                "field": Template.anchor("x"),
+                "type": "quantitative",
+                "title": Template.anchor("x_label"),
+                "scale": {"zero": False},
+            },
+            "y": {
+                "field": Template.anchor("y"),
+                "type": "nominal",
+                "title": Template.anchor("y_label"),
+                "sort": "-x",
+            },
+            "yOffset": {"field": "rev"},
+            "color": {"field": "rev", "type": "nominal"},
+        },
+    }
+
+
+class BarHorizontalUnorderedTemplate(Template):
+    DEFAULT_NAME = "bar_horizontal_unordered"
+
+    DEFAULT_CONTENT = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "data": {"values": Template.anchor("data")},
+        "title": Template.anchor("title"),
+        "width": 300,
+        "height": 300,
+        "mark": {"type": "bar"},
+        "encoding": {
+            "x": {
+                "field": Template.anchor("x"),
+                "type": "quantitative",
+                "title": Template.anchor("x_label"),
+                "scale": {"zero": False},
+            },
+            "y": {
+                "field": Template.anchor("y"),
+                "type": "nominal",
+                "title": Template.anchor("y_label"),
+            },
+            "yOffset": {"field": "rev"},
+            "color": {"field": "rev", "type": "nominal"},
+        },
+    }
+
+
 class ConfusionTemplate(Template):
     DEFAULT_NAME = "confusion"
     DEFAULT_CONTENT = {
@@ -655,6 +712,8 @@ TEMPLATES = [
     NormalizedConfusionTemplate,
     ScatterTemplate,
     SmoothLinearTemplate,
+    BarHorizontalOrderedTemplate,
+    BarHorizontalUnorderedTemplate,
 ]
 
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -111,8 +111,8 @@ class SimpleLinearTemplate(Template):
     }
 
 
-class BarHorizontalOrderedTemplate(Template):
-    DEFAULT_NAME = "bar_horizontal_ordered"
+class BarHorizontalSortedTemplate(Template):
+    DEFAULT_NAME = "bar_horizontal_sorted"
 
     DEFAULT_CONTENT = {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
@@ -140,8 +140,8 @@ class BarHorizontalOrderedTemplate(Template):
     }
 
 
-class BarHorizontalUnorderedTemplate(Template):
-    DEFAULT_NAME = "bar_horizontal_unordered"
+class BarHorizontalTemplate(Template):
+    DEFAULT_NAME = "bar_horizontal"
 
     DEFAULT_CONTENT = {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
@@ -712,8 +712,8 @@ TEMPLATES = [
     NormalizedConfusionTemplate,
     ScatterTemplate,
     SmoothLinearTemplate,
-    BarHorizontalOrderedTemplate,
-    BarHorizontalUnorderedTemplate,
+    BarHorizontalSortedTemplate,
+    BarHorizontalTemplate,
 ]
 
 


### PR DESCRIPTION
#8 Solved by this.

However, I think this is not ideal in the long run if more templates appear. The two new templates are almost identical. One could do a hotfix like this for the `BarHorizontalSorted` class:
```
    DEFAULT_CONTENT = copy.deepcopy(BarHorizontalTemplate.DEFAULT_CONTENT)
    DEFAULT_CONTENT["encoding"]["y"]["sort"] = "-x"
```
but that is quite ugly. I guess it would make sense to add optional parameters and a bit more hierarchy to the plots later if there are many variants of almost the same templates.

Also, not up to me but `vega_templates.py` is already fairly long and it might make sense to put the template class definitions into separate `.py` files.