### PR TITLE
Add `markdown` support.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,21 @@ warn_unreachable = true
 files = ["src", "tests"]
 
 [[tool.mypy.overrides]]
-module = "tabulate"
+module = [
+  "matplotlib.*",
+  "tabulate"
+]
 ignore_missing_imports = true
 
 [tool.pylint.message_control]
 enable = ["c-extension-no-member", "no-else-return"]
-disable = ["missing-module-docstring", "missing-class-docstring", "invalid-name", "R0801"]
+disable = [
+  "missing-module-docstring",
+  "missing-class-docstring",
+  "invalid-name",
+  "R0801",
+  "C0415"
+]
 
 [tool.pylint.variables]
 dummy-variables-rgx = "_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,9 @@ packages = find:
 [options.extras_require]
 table =
     tabulate>=0.8.7
+markdown =
+    %(table)s
+    matplotlib
 docs =
     mkdocs==1.3.0
     mkdocs-gen-files==0.3.4
@@ -35,6 +38,7 @@ docs =
     mkdocstrings-python==0.7.0
 tests =
     %(table)s
+    %(markdown)s
     funcy>=1.17
     pytest==7.1.2
     pytest-sugar==0.9.4
@@ -45,6 +49,7 @@ tests =
     pytest-test-utils>=0.0.6
 dev =
     %(table)s
+    %(markdown)s
     %(tests)s
     %(docs)s
 

--- a/src/dvc_render/base.py
+++ b/src/dvc_render/base.py
@@ -1,6 +1,6 @@
 import abc
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, List, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 
 if TYPE_CHECKING:
     from os import PathLike
@@ -60,6 +60,12 @@ class Renderer(abc.ABC):
 
             return self.DIV.format(id=div_id, partial=partial)
         return ""
+
+    def generate_markdown(
+        self, report_path: Optional[StrPath] = None
+    ) -> str:  # pylint: disable=missing-function-docstring
+        "Generate a markdown element"
+        raise NotImplementedError
 
     @classmethod
     def matches(

--- a/src/dvc_render/exceptions.py
+++ b/src/dvc_render/exceptions.py
@@ -1,2 +1,9 @@
 class DvcRenderException(Exception):
     pass
+
+
+class MissingPlaceholderError(DvcRenderException):
+    def __init__(self, placeholder, template_type):
+        super().__init__(
+            f"{template_type} template has to contain '{placeholder}'."
+        )

--- a/src/dvc_render/html.py
+++ b/src/dvc_render/html.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from .exceptions import DvcRenderException
 
@@ -81,7 +81,6 @@ class HTML:
 def render_html(
     renderers: List["Renderer"],
     output_file: "StrPath",
-    metrics: Optional[Dict[str, Dict]] = None,
     template_path: Optional["StrPath"] = None,
     refresh_seconds: Optional[int] = None,
 ) -> "StrPath":
@@ -95,8 +94,6 @@ def render_html(
             page_html = fobj.read()
 
     document = HTML(page_html, refresh_seconds=refresh_seconds)
-    if metrics:
-        document.with_element("<br>")
 
     for renderer in renderers:
         document.with_scripts(renderer.SCRIPTS)

--- a/src/dvc_render/image.py
+++ b/src/dvc_render/image.py
@@ -49,3 +49,14 @@ class ImageRenderer(Renderer):
             div_content.insert(0, f"<p>{self.name}</p>")
             return "\n".join(div_content)
         return ""
+
+    def generate_markdown(self, report_path=None) -> str:
+        content = []
+        for datapoint in self.datapoints:
+            src = datapoint[self.SRC_FIELD]
+            if src.startswith("data:image;base64"):
+                raise ValueError("`generate_markdown` doesn't support base64")
+            content.append(f"\n![{datapoint[self.TITLE_FIELD]}]({src})")
+        if content:
+            return "\n".join(content)
+        return ""

--- a/src/dvc_render/markdown.py
+++ b/src/dvc_render/markdown.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+from .exceptions import MissingPlaceholderError
+
+if TYPE_CHECKING:
+    from .base import Renderer, StrPath
+
+
+PAGE_MARKDOWN = """# DVC Report
+
+{renderers}
+"""
+
+
+class Markdown:
+    RENDERERS_PLACEHOLDER = "renderers"
+    RENDERERS_PLACEHOLDER_FORMAT_STR = f"{{{RENDERERS_PLACEHOLDER}}}"
+
+    def __init__(
+        self,
+        template: Optional[str] = None,
+    ):
+        template = template or PAGE_MARKDOWN
+        if self.RENDERERS_PLACEHOLDER_FORMAT_STR not in template:
+            raise MissingPlaceholderError(
+                self.RENDERERS_PLACEHOLDER_FORMAT_STR, "Markdown"
+            )
+
+        self.template = template
+        self.elements: List[str] = []
+
+    def with_element(self, md: str) -> "Markdown":
+        "Adds custom markdown element."
+        self.elements.append(md)
+        return self
+
+    def embed(self) -> str:
+        "Format Markdown template with all elements."
+        kwargs = {
+            self.RENDERERS_PLACEHOLDER: "\n".join(self.elements),
+        }
+        for placeholder, value in kwargs.items():
+            self.template = self.template.replace(
+                "{" + placeholder + "}", value
+            )
+        return self.template
+
+
+def render_markdown(
+    renderers: List["Renderer"],
+    output_file: "StrPath",
+    template_path: Optional["StrPath"] = None,
+) -> "StrPath":
+    "User renderers to fill an Markdown template and write to path."
+    output_path = Path(output_file)
+    output_path.parent.mkdir(exist_ok=True)
+
+    page = None
+    if template_path:
+        with open(template_path, encoding="utf-8") as fobj:
+            page = fobj.read()
+
+    document = Markdown(page)
+
+    for renderer in renderers:
+        document.with_element(
+            renderer.generate_markdown(report_path=output_path)
+        )
+
+    output_path.write_text(document.embed(), encoding="utf8")
+
+    return output_file

--- a/src/dvc_render/plotly.py
+++ b/src/dvc_render/plotly.py
@@ -1,8 +1,8 @@
 import json
-from collections import defaultdict
 from typing import Any, Dict, Optional
 
 from .base import Renderer
+from .utils import list_dict_to_dict_list
 
 
 class ParallelCoordinatesRenderer(Renderer):
@@ -46,10 +46,7 @@ class ParallelCoordinatesRenderer(Renderer):
         return json.dumps(self._get_plotly_data())
 
     def _get_plotly_data(self):
-        tabular_dict = defaultdict(list)
-        for row in self.datapoints:
-            for col_name, value in row.items():
-                tabular_dict[col_name].append(str(value))
+        tabular_dict = list_dict_to_dict_list(self.datapoints)
 
         trace: Dict[str, Any] = {"type": "parcoords", "dimensions": []}
         for label, values in tabular_dict.items():

--- a/src/dvc_render/utils.py
+++ b/src/dvc_render/utils.py
@@ -1,0 +1,5 @@
+def list_dict_to_dict_list(list_dict):
+    """Convert from list of dictionaries to dictionary of lists."""
+    if not list_dict:
+        return {}
+    return {k: [x[k] for x in list_dict] for k in list_dict[0]}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -29,7 +29,7 @@ def test_matches(extension, matches):
 @pytest.mark.parametrize(
     "src", ["relpath.jpg", "data:image;base64,encoded_image"]
 )
-def test_render(html_path, src):
+def test_generate_html(html_path, src):
     datapoints = [
         {
             "filename": "file.jpg",
@@ -44,6 +44,32 @@ def test_render(html_path, src):
 
     assert "<p>file.jpg</p>" in html
     assert f'<img src="{src}">' in html
+
+
+def test_generate_markdown():
+    datapoints = [
+        {
+            "rev": "workspace",
+            "src": "file.jpg",
+        }
+    ]
+
+    md = ImageRenderer(datapoints, "file.jpg").generate_markdown()
+
+    assert "![workspace](file.jpg)" in md
+
+
+def test_invalid_generate_markdown():
+    datapoints = [
+        {
+            "rev": "workspace",
+            "src": "data:image;base64,encoded_image",
+        }
+    ]
+    with pytest.raises(
+        ValueError, match="`generate_markdown` doesn't support base64"
+    ):
+        ImageRenderer(datapoints, "file.jpg").generate_markdown()
 
 
 @pytest.mark.parametrize(
@@ -81,6 +107,7 @@ def test_render_evaluate_path(tmp_dir, html_path, img_path, expected_path):
     assert f'<img src="{expected_path}">' in html
 
 
-def test_render_empty():
-    html = ImageRenderer(None, None).generate_html()
-    assert html == ""
+@pytest.mark.parametrize("method", ["generate_html", "generate_markdown"])
+def test_render_empty(method):
+    renderer = ImageRenderer(None, None)
+    assert getattr(renderer, method)() == ""

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,46 @@
+import pytest
+
+from dvc_render.markdown import (
+    PAGE_MARKDOWN,
+    Markdown,
+    MissingPlaceholderError,
+)
+
+# pylint: disable=missing-function-docstring, R0801
+
+
+CUSTOM_PAGE_MARKDOWN = """# CUSTOM REPORT
+
+{renderers}
+"""
+
+
+@pytest.mark.parametrize(
+    "template,page_elements,expected_page",
+    [
+        (
+            None,
+            ["content"],
+            PAGE_MARKDOWN.replace("{renderers}", "content"),
+        ),
+        (
+            CUSTOM_PAGE_MARKDOWN,
+            ["content"],
+            CUSTOM_PAGE_MARKDOWN.format(renderers="content"),
+        ),
+    ],
+)
+def test_html(template, page_elements, expected_page):
+    page = Markdown(template)
+    page.elements = page_elements
+
+    result = page.embed()
+
+    assert result == expected_page
+
+
+def test_no_placeholder():
+    template = "# Missing Placeholder"
+
+    with pytest.raises(MissingPlaceholderError):
+        Markdown(template)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3,7 +3,7 @@ from dvc_render.table import TableRenderer
 # pylint: disable=missing-function-docstring
 
 
-def test_render():
+def test_generate_html():
     datapoints = [
         {"foo": 1, "bar": 2},
     ]
@@ -13,3 +13,14 @@ def test_render():
     assert '<th style="text-align: right;">  bar</th></tr>' in html
     assert '<td style="text-align: right;">    1</td>' in html
     assert '<td style="text-align: right;">    2</td>' in html
+
+
+def test_generate_markdown():
+    datapoints = [
+        {"foo": 1, "bar": 2},
+    ]
+    md = TableRenderer(datapoints, "metrics.json").generate_markdown()
+    assert "metrics.json\n\n" in md
+    assert "|   foo |   bar |" in md
+    assert "|-------|-------|" in md
+    assert "|     1 |     2 |" in md


### PR DESCRIPTION
Cutting quite a few corners to cover the minimum for https://github.com/iterative/dvclive/issues/91

Proper refactor would make sense as follow-up because the whole package was focused on a single output format (HTML).

---

table: Add `generate_markdown`.

image: Add `generate_markdown`.

vega: Add `generate_markdown`.

"Translate" vega plot to `matplotlib` figure to save as `png`.

Introduce `render_markdown`.

Closes #62