### PR TITLE
vega: Escape special characters in `field` and `title`.

### DIFF
--- a/src/dvc_render/vega.py
+++ b/src/dvc_render/vega.py
@@ -81,6 +81,8 @@ class VegaRenderer(Renderer):
                         f"Template '{self.template.name}' "
                         f"is not using '{anchor}' anchor"
                     )
+            else:
+                value = self.template.escape_special_characters(value)
             content = self.template.fill_anchor(content, name, value)
 
         return content

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -73,6 +73,13 @@ class Template:
         return content.replace(cls.anchor_str(name), value_str)
 
     @classmethod
+    def escape_special_characters(cls, value: str) -> str:
+        "Escape special characters in `value`"
+        for character in (".", "[", "]"):
+            value = value.replace(character, "\\" + character)
+        return value
+
+    @classmethod
     def anchor_str(cls, name) -> str:
         "Get string wrapping ANCHOR formatted with name."
         return f'"{cls.anchor(name)}"'

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -6,6 +6,7 @@ from dvc_render.vega_templates import (
     TEMPLATES,
     LinearTemplate,
     ScatterTemplate,
+    Template,
     TemplateContentDoesNotMatch,
     TemplateNotFoundError,
     dump_templates,
@@ -76,3 +77,8 @@ def test_raise_on_init_modified(tmp_dir):
 
     with pytest.raises(TemplateContentDoesNotMatch):
         dump_templates(output=".", targets=["linear"])
+
+
+def test_escape_special_characters():
+    value = "foo.bar[2]"
+    assert Template.escape_special_characters(value) == "foo\\.bar\\[2\\]"

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -159,3 +159,20 @@ def test_invalid_generate_markdown():
         match="`generate_markdown` can only be used with `LinearTemplate`",
     ):
         renderer.generate_markdown("output")
+
+
+def test_escape_special_characters():
+    datapoints = [
+        {"foo.bar[0]": 0, "foo.bar[1]": 3},
+        {"foo.bar[0]": 1, "foo.bar[1]": 4},
+    ]
+    props = {"template": "simple", "x": "foo.bar[0]", "y": "foo.bar[1]"}
+    renderer = VegaRenderer(datapoints, "foo", **props)
+    filled = json.loads(renderer.get_filled_template())
+    # data is not escaped
+    assert filled["data"]["values"][0] == datapoints[0]
+    # field and title yes
+    assert filled["encoding"]["x"]["field"] == "foo\\.bar\\[0\\]"
+    assert filled["encoding"]["x"]["title"] == "foo\\.bar\\[0\\]"
+    assert filled["encoding"]["y"]["field"] == "foo\\.bar\\[1\\]"
+    assert filled["encoding"]["y"]["title"] == "foo\\.bar\\[1\\]"


### PR DESCRIPTION
Closes #80