### PR TITLE
vega: Only escape `field`.

### DIFF
--- a/src/dvc_render/vega.py
+++ b/src/dvc_render/vega.py
@@ -81,7 +81,7 @@ class VegaRenderer(Renderer):
                         f"Template '{self.template.name}' "
                         f"is not using '{anchor}' anchor"
                     )
-            else:
+            elif name in {"x", "y"}:
                 value = self.template.escape_special_characters(value)
             content = self.template.fill_anchor(content, name, value)
 

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -173,6 +173,6 @@ def test_escape_special_characters():
     assert filled["data"]["values"][0] == datapoints[0]
     # field and title yes
     assert filled["encoding"]["x"]["field"] == "foo\\.bar\\[0\\]"
-    assert filled["encoding"]["x"]["title"] == "foo\\.bar\\[0\\]"
+    assert filled["encoding"]["x"]["title"] == "foo.bar[0]"
     assert filled["encoding"]["y"]["field"] == "foo\\.bar\\[1\\]"
-    assert filled["encoding"]["y"]["title"] == "foo\\.bar\\[1\\]"
+    assert filled["encoding"]["y"]["title"] == "foo.bar[1]"


### PR DESCRIPTION
Unnecesary escaping for `title` and labels was added in #81.