### PR TITLE
TableRenderer: Include first new line.

### DIFF
--- a/src/dvc_render/markdown.py
+++ b/src/dvc_render/markdown.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
 
 
 PAGE_MARKDOWN = """# DVC Report
-
 {renderers}
 """
 

--- a/src/dvc_render/table.py
+++ b/src/dvc_render/table.py
@@ -36,4 +36,4 @@ class TableRenderer(Renderer):
 
     def generate_markdown(self, report_path=None) -> str:
         table = self.to_tabulate(self.datapoints, tablefmt="github")
-        return f"{self.name}\n\n{table}"
+        return f"\n{self.name}\n\n{table}"


### PR DESCRIPTION
Using 2 Tablerenderers sequantially breaks the first one unless the new line is introduced.

Before:

```
params.yaml

|   foobar |
|----------|
|        0 |
dvclive.json

|   step |   foo |
|--------|-------|
|      0 |     1 |
```

After:
```

params.yaml

|   foobar |
|----------|
|        0 |

dvclive.json

|   step |   foo |
|--------|-------|
|      0 |     1 |
```