### PR TITLE
vega: generate_markdown: Don't raise exception for unsupported templa…

### DIFF
--- a/src/dvc_render/vega.py
+++ b/src/dvc_render/vega.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional
+from warnings import warn
 
 from .base import Renderer
 from .exceptions import DvcRenderException
@@ -92,9 +93,8 @@ class VegaRenderer(Renderer):
 
     def generate_markdown(self, report_path=None) -> str:
         if not isinstance(self.template, LinearTemplate):
-            raise ValueError(
-                "`generate_markdown` can only be used with `LinearTemplate`"
-            )
+            warn("`generate_markdown` can only be used with `LinearTemplate`")
+            return ""
         try:
             from matplotlib import pyplot as plt
         except ImportError as e:

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -145,7 +145,7 @@ def test_generate_markdown(tmp_dir, mocker, name):
     savefig.assert_called_with((tmp_dir / "output" / name).with_suffix(".png"))
 
 
-def test_invalid_generate_markdown():
+def test_unsupported_template():
     datapoints = [
         {"predicted": "B", "actual": "A"},
         {"predicted": "A", "actual": "A"},
@@ -154,11 +154,12 @@ def test_invalid_generate_markdown():
 
     renderer = VegaRenderer(datapoints, "foo", **props)
 
-    with pytest.raises(
-        ValueError,
-        match="`generate_markdown` can only be used with `LinearTemplate`",
+    # Skip with warning instead of raising exception
+    with pytest.warns(
+        match="`generate_markdown` can only be used with `LinearTemplate`"
     ):
-        renderer.generate_markdown("output")
+        out = renderer.generate_markdown("output")
+    assert out == ""
 
 
 def test_escape_special_characters():


### PR DESCRIPTION
…tes.

So a code like:

```
with Live(dir='dvclive', report='md') as live:
    live.log_sklearn_plot("calibration", y_true, y_score)
    live.log_sklearn_plot("confusion_matrix", y_true, y_pred)
    live.log_sklearn_plot("det", y_true, y_score)
    live.log_sklearn_plot("precision_recall", y_true, y_score)
    live.log_sklearn_plot("roc", y_true, y_score)
```

Still generates a valid report for the supported plots instead of failing and not generating anything.