### PR TITLE
add params for smoothing and hiding points in linear template

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -464,126 +464,6 @@ class ScatterTemplate(Template):
     }
 
 
-class SmoothLinearTemplate(Template):
-    DEFAULT_NAME = "smooth"
-    DEFAULT_CONTENT = {
-        "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-        "data": {"values": Template.anchor("data")},
-        "title": Template.anchor("title"),
-        "width": 300,
-        "height": 300,
-        "params": [
-            {
-                "name": "smooth",
-                "value": 0.2,
-                "bind": {
-                    "input": "range",
-                    "min": 0.001,
-                    "max": 1,
-                    "step": 0.01,
-                },
-            },
-        ],
-        "transform": [
-            {
-                "loess": Template.anchor("y"),
-                "on": Template.anchor("x"),
-                "groupby": ["rev"],
-                "bandwidth": {"signal": "smooth"},
-            }
-        ],
-        "layer": [
-            {
-                "encoding": {
-                    "x": {
-                        "field": Template.anchor("x"),
-                        "type": "quantitative",
-                        "title": Template.anchor("x_label"),
-                    },
-                    "y": {
-                        "field": Template.anchor("y"),
-                        "type": "quantitative",
-                        "title": Template.anchor("y_label"),
-                        "scale": {"zero": False},
-                    },
-                    "color": {"field": "rev", "type": "nominal"},
-                },
-                "layer": [
-                    {"mark": "line", "point": True},
-                    {
-                        "selection": {
-                            "label": {
-                                "type": "single",
-                                "nearest": True,
-                                "on": "mouseover",
-                                "encodings": ["x"],
-                                "empty": "none",
-                                "clear": "mouseout",
-                            }
-                        },
-                        "mark": "point",
-                        "encoding": {
-                            "opacity": {
-                                "condition": {
-                                    "selection": "label",
-                                    "value": 1,
-                                },
-                                "value": 0,
-                            }
-                        },
-                    },
-                ],
-            },
-            {
-                "transform": [{"filter": {"selection": "label"}}],
-                "layer": [
-                    {
-                        "mark": {"type": "rule", "color": "gray"},
-                        "encoding": {
-                            "x": {
-                                "field": Template.anchor("x"),
-                                "type": "quantitative",
-                            }
-                        },
-                    },
-                    {
-                        "encoding": {
-                            "text": {
-                                "type": "quantitative",
-                                "field": Template.anchor("y"),
-                            },
-                            "x": {
-                                "field": Template.anchor("x"),
-                                "type": "quantitative",
-                            },
-                            "y": {
-                                "field": Template.anchor("y"),
-                                "type": "quantitative",
-                            },
-                        },
-                        "layer": [
-                            {
-                                "mark": {
-                                    "type": "text",
-                                    "align": "left",
-                                    "dx": 5,
-                                    "dy": -5,
-                                },
-                                "encoding": {
-                                    "color": {
-                                        "type": "nominal",
-                                        "field": "rev",
-                                    }
-                                },
-                            }
-                        ],
-                    },
-                ],
-            },
-        ],
-    }
-
-
 class LinearTemplate(Template):
     DEFAULT_NAME = "linear"
 
@@ -645,6 +525,10 @@ class LinearTemplate(Template):
 
 class SimpleLinearTemplate(LinearTemplate):
     DEFAULT_NAME = "simple"
+
+
+class SmoothLinearTemplate(LinearTemplate):
+    DEFAULT_NAME = "smooth"
 
 
 TEMPLATES = [

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -520,6 +520,14 @@ class LinearTemplate(Template):
                 },
             },
         ],
+        "transform": [
+            {
+                "loess": Template.anchor("y"),
+                "on": Template.anchor("x"),
+                "groupby": ["rev", "filename"],
+                "bandwidth": {"signal": "smooth"},
+            }
+        ],
     }
 
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -595,7 +595,9 @@ class LinearTemplate(Template):
         "height": 300,
         "mark": {
             "type": "line",
-            "point": True,
+            "point": {
+                "size": {"expr": "points"}
+            },
             "tooltip": {"content": "data"},
         },
         "encoding": {
@@ -612,6 +614,35 @@ class LinearTemplate(Template):
             },
             "color": {"field": "rev", "type": "nominal"},
         },
+        "params": [
+            {
+              "name": "points",
+              "value": 0,
+              "bind": {
+                "input": "radio",
+                "options": [30, 0],
+                "labels": ["show", "hide"]
+              }
+            },
+            {
+                "name": "smooth",
+                "value": 0.001,
+                "bind": {
+                    "input": "range",
+                    "min": 0.001,
+                    "max": 1,
+                    "step": 0.001,
+                },
+            },
+        ],
+        "transform": [
+            {
+                "loess": Template.anchor("y"),
+                "on": Template.anchor("x"),
+                "groupby": ["rev"],
+                "bandwidth": {"signal": "smooth"},
+            }
+        ],
     }
 
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -596,7 +596,7 @@ class LinearTemplate(Template):
         "mark": {
             "type": "line",
             "point": {
-                "size": {"expr": "points"}
+                "opacity": {"expr": "opacity"}
             },
             "tooltip": {"content": "data"},
         },
@@ -616,13 +616,14 @@ class LinearTemplate(Template):
         },
         "params": [
             {
-              "name": "points",
-              "value": 0,
-              "bind": {
-                "input": "radio",
-                "options": [30, 0],
-                "labels": ["show", "hide"]
-              }
+                "name": "opacity",
+                "value": 0.1,
+                "bind": {
+                    "input": "range",
+                    "min": 0,
+                    "max": 1,
+                    "step": 0.1,
+                },
             },
             {
                 "name": "smooth",
@@ -634,14 +635,6 @@ class LinearTemplate(Template):
                     "step": 0.001,
                 },
             },
-        ],
-        "transform": [
-            {
-                "loess": Template.anchor("y"),
-                "on": Template.anchor("x"),
-                "groupby": ["rev"],
-                "bandwidth": {"signal": "smooth"},
-            }
         ],
     }
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -612,7 +612,11 @@ class LinearTemplate(Template):
                 "title": Template.anchor("y_label"),
                 "scale": {"zero": False},
             },
-            "color": {"field": "rev", "type": "nominal"},
+            "color": {
+                "field": "rev",
+                "type": "nominal",
+                "legend": {"symbolOpacity": 1},
+            },
         },
         "params": [
             {


### PR DESCRIPTION
Adds point opacity and smoothing to the linear template:

<img width="588" alt="Screenshot 2023-01-20 at 3 55 45 PM" src="https://user-images.githubusercontent.com/2308172/213803597-1935cc45-0e7e-40b8-9e7c-cdcd8b10741d.png">

This is needed to generate nice looking example plots (see https://github.com/iterative/dvclive/issues/424), and it seems useful to give people options to modify in the UI instead of having to update the template.

This will break plots in VS Code until https://github.com/iterative/vscode-dvc/issues/3130 is fixed, so we should wait on that.