### PR TITLE
Update smooth template: default tooltip, group by filename

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -488,7 +488,7 @@ class SmoothLinearTemplate(Template):
             {
                 "loess": Template.anchor("y"),
                 "on": Template.anchor("x"),
-                "groupby": ["rev"],
+                "groupby": ["rev", "filename"],
                 "bandwidth": {"signal": "smooth"},
             }
         ],
@@ -509,77 +509,15 @@ class SmoothLinearTemplate(Template):
                     "color": {"field": "rev", "type": "nominal"},
                 },
                 "layer": [
-                    {"mark": "line", "point": True},
                     {
-                        "selection": {
-                            "label": {
-                                "type": "single",
-                                "nearest": True,
-                                "on": "mouseover",
-                                "encodings": ["x"],
-                                "empty": "none",
-                                "clear": "mouseout",
-                            }
-                        },
-                        "mark": "point",
-                        "encoding": {
-                            "opacity": {
-                                "condition": {
-                                    "selection": "label",
-                                    "value": 1,
-                                },
-                                "value": 0,
-                            }
-                        },
-                    },
+                        "mark": {
+                            "type": "line",
+                            "point": True,
+                            "tooltip": {"content": "data"},
+                        }
+                    }
                 ],
-            },
-            {
-                "transform": [{"filter": {"selection": "label"}}],
-                "layer": [
-                    {
-                        "mark": {"type": "rule", "color": "gray"},
-                        "encoding": {
-                            "x": {
-                                "field": Template.anchor("x"),
-                                "type": "quantitative",
-                            }
-                        },
-                    },
-                    {
-                        "encoding": {
-                            "text": {
-                                "type": "quantitative",
-                                "field": Template.anchor("y"),
-                            },
-                            "x": {
-                                "field": Template.anchor("x"),
-                                "type": "quantitative",
-                            },
-                            "y": {
-                                "field": Template.anchor("y"),
-                                "type": "quantitative",
-                            },
-                        },
-                        "layer": [
-                            {
-                                "mark": {
-                                    "type": "text",
-                                    "align": "left",
-                                    "dx": 5,
-                                    "dy": -5,
-                                },
-                                "encoding": {
-                                    "color": {
-                                        "type": "nominal",
-                                        "field": "rev",
-                                    }
-                                },
-                            }
-                        ],
-                    },
-                ],
-            },
+            }
         ],
     }
 


### PR DESCRIPTION
Fixes https://github.com/iterative/vscode-dvc/pull/3132


`--json` returns data points in a slightly different format compared to the regular `--show-vega` (which is how DVC renders it I think):

```json
{
        "precision": 0.3043014798093805,
        "recall": 1,
        "threshold": 0.00033803811731466854,
        "dvc_data_version_info": {
          "filename": "eval/prc/train.json",
          "field": "precision"
        },
        "filename": "eval/prc/train.json",
        "field": "precision",
        "rev": "try-large-dataset"
      }
```

vs

```json
{
        "precision": 0.30396793085089724,
        "recall": 1.0,
        "rev": "<rev>:eval/prc/train.json",
        "threshold": 0.00022598870056497175
      }
```

`transform` applied in the `smooth` template was grouping points by `rev` only, which was fine in a regular case since `rev` field include both `rev` _and_ file name for flexible plots. Not enough in case of `--json` since filename is a separate field there.

This PR also updates the style (tooltip, line with points to show a single value, etc) to be up to date with the default one (`linear`).

https://user-images.githubusercontent.com/3659196/213902344-a269da16-d919-4e4e-b3dd-4b6c21417fb0.mov

https://user-images.githubusercontent.com/3659196/213902526-b3e8e3f2-89ae-46f8-82a9-887f157b60bf.mov


