### PR TITLE
minor changes to smooth template

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -505,7 +505,7 @@ class SmoothLinearTemplate(Template):
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["rev", "filename"],
+                        "groupby": ["rev", "filename", "field"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -113,7 +113,11 @@ class BarHorizontalSortedTemplate(Template):
                 "sort": "-x",
             },
             "yOffset": {"field": "rev"},
-            "color": {"field": "rev", "type": "nominal"},
+            "color": {
+                "field": "rev",
+                "type": "nominal",
+                "legend": {"orient": "top", "direction": "vertical"},
+            },
         },
     }
 
@@ -141,7 +145,11 @@ class BarHorizontalTemplate(Template):
                 "title": Template.anchor("y_label"),
             },
             "yOffset": {"field": "rev"},
-            "color": {"field": "rev", "type": "nominal"},
+            "color": {
+                "field": "rev",
+                "type": "nominal",
+                "legend": {"orient": "top", "direction": "vertical"},
+            },
         },
     }
 
@@ -393,7 +401,11 @@ class ScatterTemplate(Template):
                         "title": Template.anchor("y_label"),
                         "scale": {"zero": False},
                     },
-                    "color": {"field": "rev", "type": "nominal"},
+                    "color": {
+                        "field": "rev",
+                        "type": "nominal",
+                        "legend": {"orient": "top", "direction": "vertical"},
+                    },
                 },
                 "layer": [
                     {"mark": "point"},
@@ -507,7 +519,7 @@ class SmoothLinearTemplate(Template):
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["rev", "filename::field"],
+                        "groupby": ["rev", "filename", "field", "filename::field"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -480,20 +480,13 @@ class SmoothLinearTemplate(Template):
                     "input": "range",
                     "min": 0.001,
                     "max": 1,
-                    "step": 0.01,
+                    "step": 0.001,
                 },
             },
         ],
-        "transform": [
-            {
-                "loess": Template.anchor("y"),
-                "on": Template.anchor("x"),
-                "groupby": ["rev", "filename"],
-                "bandwidth": {"signal": "smooth"},
-            }
-        ],
         "layer": [
             {
+                "mark": "line",
                 "encoding": {
                     "x": {
                         "field": Template.anchor("x"),
@@ -508,16 +501,35 @@ class SmoothLinearTemplate(Template):
                     },
                     "color": {"field": "rev", "type": "nominal"},
                 },
-                "layer": [
+                "transform": [
                     {
-                        "mark": {
-                            "type": "line",
-                            "point": True,
-                            "tooltip": {"content": "data"},
-                        }
-                    }
+                        "loess": Template.anchor("y"),
+                        "on": Template.anchor("x"),
+                        "groupby": ["rev", "filename"],
+                        "bandwidth": {"signal": "smooth"},
+                    },
                 ],
-            }
+            },
+            {
+                "mark": {
+                    "type": "point",
+                    "tooltip": {"content": "data"},
+                },
+                "encoding": {
+                    "x": {
+                        "field": Template.anchor("x"),
+                        "type": "quantitative",
+                        "title": Template.anchor("x_label"),
+                    },
+                    "y": {
+                        "field": Template.anchor("y"),
+                        "type": "quantitative",
+                        "title": Template.anchor("y_label"),
+                        "scale": {"zero": False},
+                    },
+                    "color": {"field": "rev", "type": "nominal"},
+                },
+            },
         ],
     }
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -475,7 +475,7 @@ class SmoothLinearTemplate(Template):
         "params": [
             {
                 "name": "smooth",
-                "value": 0.2,
+                "value": 0.001,
                 "bind": {
                     "input": "range",
                     "min": 0.001,
@@ -505,7 +505,7 @@ class SmoothLinearTemplate(Template):
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["rev", "filename", "field"],
+                        "groupby": ["rev", "filename::field"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],
@@ -534,8 +534,12 @@ class SmoothLinearTemplate(Template):
     }
 
 
-class LinearTemplate(Template):
+class LinearTemplate(SmoothLinearTemplate):
     DEFAULT_NAME = "linear"
+
+
+class SimpleLinearTemplate(Template):
+    DEFAULT_NAME = "simple"
 
     DEFAULT_CONTENT = {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
@@ -545,7 +549,6 @@ class LinearTemplate(Template):
         "height": 300,
         "mark": {
             "type": "line",
-            "point": True,
             "tooltip": {"content": "data"},
         },
         "encoding": {
@@ -563,10 +566,6 @@ class LinearTemplate(Template):
             "color": {"field": "rev", "type": "nominal"},
         },
     }
-
-
-class SimpleLinearTemplate(LinearTemplate):
-    DEFAULT_NAME = "simple"
 
 
 TEMPLATES = [

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -45,9 +45,10 @@ def test_default_template_mark():
 
     plot_content = json.loads(VegaRenderer(datapoints, "foo").partial_html())
 
-    assert plot_content["mark"] == {
-        "type": "line",
-        "point": True,
+    assert plot_content["layer"][0]["mark"] == "line"
+
+    assert plot_content["layer"][1]["mark"] == {
+        "type": "point",
         "tooltip": {"content": "data"},
     }
 
@@ -73,8 +74,8 @@ def test_choose_axes():
             "second_val": 300,
         },
     ]
-    assert plot_content["encoding"]["x"]["field"] == "first_val"
-    assert plot_content["encoding"]["y"]["field"] == "second_val"
+    assert plot_content["layer"][0]["encoding"]["x"]["field"] == "first_val"
+    assert plot_content["layer"][0]["encoding"]["y"]["field"] == "second_val"
 
 
 def test_confusion():


### PR DESCRIPTION
This does complicate the template, but there were a few things bothering me playing around with the `smooth` template that are fixed here:

1. Extra fields like `thresholds` are now shown in the tooltip.

<img width="1052" alt="Screenshot 2023-01-24 at 4 24 54 PM" src="https://user-images.githubusercontent.com/2308172/214426138-768d3841-0cee-4b26-9dbd-f37e9693386c.png">

2. Smoothing impacts only the line, not the points (if you search for loess smoothing, this is more common, and it allows you to simultaneously see the trend and the actual values of the points).

<img width="956" alt="Screenshot 2023-01-24 at 4 35 55 PM" src="https://user-images.githubusercontent.com/2308172/214426320-b67a79f5-152e-416f-9eae-c59137197c5f.png">

3. 💅 Because of the combination of values of the min, default, and step values, the slider would always get stuck on odd values (for example, it would max out at 0.991).

