### PR TITLE
Use `dvc_...` fields from https://github.com/iterative/dvc/pull/9019

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -116,7 +116,8 @@ class BarHorizontalSortedTemplate(Template):
             },
             "yOffset": {"field": "dvc_id"},
             "color": {"field": "dvc_rev", "type": "nominal"},
-            "strokeDash": {"field": "dvc_source", "type": "nominal"},
+            "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+            "shape": {"field": "dvc_field", "type": "nominal"},
         },
     }
 
@@ -145,7 +146,8 @@ class BarHorizontalTemplate(Template):
             },
             "yOffset": {"field": "dvc_id"},
             "color": {"field": "dvc_rev", "type": "nominal"},
-            "strokeDash": {"field": "dvc_source", "type": "nominal"},
+            "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+            "shape": {"field": "dvc_field", "type": "nominal"},
         },
     }
 
@@ -159,7 +161,7 @@ class ConfusionTemplate(Template):
         "facet": {
             "field": "dvc_id",
             "type": "nominal",
-            "header": {"title": False}
+            "header": {"title": False},
         },
         "spec": {
             "transform": [
@@ -273,7 +275,7 @@ class NormalizedConfusionTemplate(Template):
         "facet": {
             "field": "dvc_id",
             "type": "nominal",
-            "header": {"title": False}
+            "header": {"title": False},
         },
         "spec": {
             "transform": [
@@ -406,7 +408,8 @@ class ScatterTemplate(Template):
                         "scale": {"zero": False},
                     },
                     "color": {"field": "dvc_rev", "type": "nominal"},
-                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+                    "shape": {"field": "dvc_field", "type": "nominal"},
                 },
                 "layer": [
                     {"mark": "point"},
@@ -466,8 +469,12 @@ class ScatterTemplate(Template):
                                         "field": "dvc_rev",
                                     },
                                     "strokeDash": {
-                                        "field": "dvc_source",
-                                        "type": "nominal"
+                                        "field": "dvc_filename",
+                                        "type": "nominal",
+                                    },
+                                    "shape": {
+                                        "field": "dvc_field",
+                                        "type": "nominal",
                                     },
                                 },
                             }
@@ -515,13 +522,14 @@ class SmoothLinearTemplate(Template):
                         "scale": {"zero": False},
                     },
                     "color": {"field": "dvc_rev", "type": "nominal"},
-                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+                    "shape": {"field": "dvc_field", "type": "nominal"},
                 },
                 "transform": [
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["dvc_rev", "dvc_source"],
+                        "groupby": ["dvc_id"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],
@@ -544,7 +552,8 @@ class SmoothLinearTemplate(Template):
                         "scale": {"zero": False},
                     },
                     "color": {"field": "dvc_rev", "type": "nominal"},
-                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+                    "shape": {"field": "dvc_field", "type": "nominal"},
                 },
             },
         ],
@@ -581,9 +590,11 @@ class SimpleLinearTemplate(Template):
                 "scale": {"zero": False},
             },
             "color": {"field": "dvc_rev", "type": "nominal"},
-            "strokeDash": {"field": "dvc_source", "type": "nominal"},
+            "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+            "shape": {"field": "dvc_field", "type": "nominal"},
         },
     }
+
 
 TEMPLATES = [
     SimpleLinearTemplate,

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -402,10 +402,10 @@ class ScatterTemplate(Template):
                 "field": Template.anchor("y"),
                 "type": "quantitative",
                 "title": Template.anchor("y_label"),
-                "color": {"field": "dvc_rev", "type": "nominal"},
-                "strokeDash": {"field": "dvc_filename", "type": "nominal"},
-                "shape": {"field": "dvc_field", "type": "nominal"},
             },
+            "color": {"field": "dvc_rev", "type": "nominal"},
+            "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+            "shape": {"field": "dvc_field", "type": "nominal"},
         },
     }
 
@@ -433,10 +433,9 @@ class ScatterJitterTemplate(Template):
                 "field": Template.anchor("y"),
                 "title": Template.anchor("y_label"),
             },
-            "color": {
-                "field": "rev",
-                "type": "nominal",
-            },
+            "color": {"field": "dvc_rev", "type": "nominal"},
+            "strokeDash": {"field": "dvc_filename", "type": "nominal"},
+            "shape": {"field": "dvc_field", "type": "nominal"},
             "xOffset": {"field": "randomX", "type": "quantitative"},
             "yOffset": {"field": "randomY", "type": "quantitative"},
         },
@@ -465,7 +464,10 @@ class SmoothLinearTemplate(Template):
         ],
         "layer": [
             {
-                "mark": "line",
+                "mark": {
+                    "type": "line",
+                    "fill": "transparent",
+                },
                 "encoding": {
                     "x": {
                         "field": Template.anchor("x"),
@@ -486,7 +488,7 @@ class SmoothLinearTemplate(Template):
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["dvc_id"],
+                        "groupby": ["dvc_rev", "dvc_filename", "dvc_field"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],
@@ -533,6 +535,7 @@ class SimpleLinearTemplate(Template):
         "mark": {
             "type": "line",
             "tooltip": {"content": "data"},
+            "fill": "transparent",
         },
         "encoding": {
             "x": {

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -505,7 +505,7 @@ class SmoothLinearTemplate(Template):
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["rev", "filename"],
+                        "groupby": ["rev", "filename", "field"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -480,20 +480,13 @@ class SmoothLinearTemplate(Template):
                     "input": "range",
                     "min": 0.001,
                     "max": 1,
-                    "step": 0.01,
+                    "step": 0.001,
                 },
             },
         ],
-        "transform": [
-            {
-                "loess": Template.anchor("y"),
-                "on": Template.anchor("x"),
-                "groupby": ["rev", "filename"],
-                "bandwidth": {"signal": "smooth"},
-            }
-        ],
         "layer": [
             {
+                "mark": "line",
                 "encoding": {
                     "x": {
                         "field": Template.anchor("x"),
@@ -508,16 +501,35 @@ class SmoothLinearTemplate(Template):
                     },
                     "color": {"field": "rev", "type": "nominal"},
                 },
-                "layer": [
+                "transform": [
                     {
-                        "mark": {
-                            "type": "line",
-                            "point": True,
-                            "tooltip": {"content": "data"},
-                        }
-                    }
+                        "loess": Template.anchor("y"),
+                        "on": Template.anchor("x"),
+                        "groupby": ["rev", "filename"],
+                        "bandwidth": {"signal": "smooth"},
+                    },
                 ],
-            }
+            },
+            {
+                "mark": {
+                    "type": "point",
+                    "tooltip": {"content": "data"},
+                },
+                "encoding": {
+                    "x": {
+                        "field": Template.anchor("x"),
+                        "type": "quantitative",
+                        "title": Template.anchor("x_label"),
+                    },
+                    "y": {
+                        "field": Template.anchor("y"),
+                        "type": "quantitative",
+                        "title": Template.anchor("y_label"),
+                        "scale": {"zero": False},
+                    },
+                    "color": {"field": "rev", "type": "nominal"},
+                },
+            },
         ],
     }
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -114,8 +114,9 @@ class BarHorizontalSortedTemplate(Template):
                 "title": Template.anchor("y_label"),
                 "sort": "-x",
             },
-            "yOffset": {"field": "rev"},
-            "color": {"field": "rev", "type": "nominal"},
+            "yOffset": {"field": "dvc_id"},
+            "color": {"field": "dvc_rev", "type": "nominal"},
+            "strokeDash": {"field": "dvc_source", "type": "nominal"},
         },
     }
 
@@ -142,8 +143,9 @@ class BarHorizontalTemplate(Template):
                 "type": "nominal",
                 "title": Template.anchor("y_label"),
             },
-            "yOffset": {"field": "rev"},
-            "color": {"field": "rev", "type": "nominal"},
+            "yOffset": {"field": "dvc_id"},
+            "color": {"field": "dvc_rev", "type": "nominal"},
+            "strokeDash": {"field": "dvc_source", "type": "nominal"},
         },
     }
 
@@ -154,7 +156,11 @@ class ConfusionTemplate(Template):
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
         "data": {"values": Template.anchor("data")},
         "title": Template.anchor("title"),
-        "facet": {"field": "rev", "type": "nominal"},
+        "facet": {
+            "field": "dvc_id",
+            "type": "nominal",
+            "header": {"title": False}
+        },
         "spec": {
             "transform": [
                 {
@@ -163,13 +169,13 @@ class ConfusionTemplate(Template):
                 },
                 {
                     "impute": "xy_count",
-                    "groupby": ["rev", Template.anchor("y")],
+                    "groupby": ["dvc_id", Template.anchor("y")],
                     "key": Template.anchor("x"),
                     "value": 0,
                 },
                 {
                     "impute": "xy_count",
-                    "groupby": ["rev", Template.anchor("x")],
+                    "groupby": ["dvc_id", Template.anchor("x")],
                     "key": Template.anchor("y"),
                     "value": 0,
                 },
@@ -264,7 +270,11 @@ class NormalizedConfusionTemplate(Template):
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
         "data": {"values": Template.anchor("data")},
         "title": Template.anchor("title"),
-        "facet": {"field": "rev", "type": "nominal"},
+        "facet": {
+            "field": "dvc_id",
+            "type": "nominal",
+            "header": {"title": False}
+        },
         "spec": {
             "transform": [
                 {
@@ -273,13 +283,13 @@ class NormalizedConfusionTemplate(Template):
                 },
                 {
                     "impute": "xy_count",
-                    "groupby": ["rev", Template.anchor("y")],
+                    "groupby": ["dvc_id", Template.anchor("y")],
                     "key": Template.anchor("x"),
                     "value": 0,
                 },
                 {
                     "impute": "xy_count",
-                    "groupby": ["rev", Template.anchor("x")],
+                    "groupby": ["dvc_id", Template.anchor("x")],
                     "key": Template.anchor("y"),
                     "value": 0,
                 },
@@ -395,7 +405,8 @@ class ScatterTemplate(Template):
                         "title": Template.anchor("y_label"),
                         "scale": {"zero": False},
                     },
-                    "color": {"field": "rev", "type": "nominal"},
+                    "color": {"field": "dvc_rev", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
                 },
                 "layer": [
                     {"mark": "point"},
@@ -452,8 +463,12 @@ class ScatterTemplate(Template):
                                 "encoding": {
                                     "color": {
                                         "type": "nominal",
-                                        "field": "rev",
-                                    }
+                                        "field": "dvc_rev",
+                                    },
+                                    "strokeDash": {
+                                        "field": "dvc_source",
+                                        "type": "nominal"
+                                    },
                                 },
                             }
                         ],
@@ -475,7 +490,7 @@ class SmoothLinearTemplate(Template):
         "params": [
             {
                 "name": "smooth",
-                "value": 0.2,
+                "value": 0.001,
                 "bind": {
                     "input": "range",
                     "min": 0.001,
@@ -499,13 +514,14 @@ class SmoothLinearTemplate(Template):
                         "title": Template.anchor("y_label"),
                         "scale": {"zero": False},
                     },
-                    "color": {"field": "rev", "type": "nominal"},
+                    "color": {"field": "dvc_rev", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
                 },
                 "transform": [
                     {
                         "loess": Template.anchor("y"),
                         "on": Template.anchor("x"),
-                        "groupby": ["rev", "filename", "field"],
+                        "groupby": ["dvc_rev", "dvc_source"],
                         "bandwidth": {"signal": "smooth"},
                     },
                 ],
@@ -527,15 +543,20 @@ class SmoothLinearTemplate(Template):
                         "title": Template.anchor("y_label"),
                         "scale": {"zero": False},
                     },
-                    "color": {"field": "rev", "type": "nominal"},
+                    "color": {"field": "dvc_rev", "type": "nominal"},
+                    "strokeDash": {"field": "dvc_source", "type": "nominal"},
                 },
             },
         ],
     }
 
 
-class LinearTemplate(Template):
+class LinearTemplate(SmoothLinearTemplate):
     DEFAULT_NAME = "linear"
+
+
+class SimpleLinearTemplate(Template):
+    DEFAULT_NAME = "simple"
 
     DEFAULT_CONTENT = {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
@@ -545,7 +566,6 @@ class LinearTemplate(Template):
         "height": 300,
         "mark": {
             "type": "line",
-            "point": True,
             "tooltip": {"content": "data"},
         },
         "encoding": {
@@ -560,14 +580,10 @@ class LinearTemplate(Template):
                 "title": Template.anchor("y_label"),
                 "scale": {"zero": False},
             },
-            "color": {"field": "rev", "type": "nominal"},
+            "color": {"field": "dvc_rev", "type": "nominal"},
+            "strokeDash": {"field": "dvc_source", "type": "nominal"},
         },
     }
-
-
-class SimpleLinearTemplate(LinearTemplate):
-    DEFAULT_NAME = "simple"
-
 
 TEMPLATES = [
     SimpleLinearTemplate,

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -45,7 +45,7 @@ def test_default_template_mark():
 
     plot_content = json.loads(VegaRenderer(datapoints, "foo").partial_html())
 
-    assert plot_content["layer"][0]["mark"] == "line"
+    assert plot_content["layer"][0]["mark"] == {"type": "line", "fill": "transparent"}
 
     assert plot_content["layer"][1]["mark"] == {
         "type": "point",


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/pull/9018.

Depends on https://github.com/iterative/dvc/pull/9019.

This incorporates the fields introduced by the linked DVC pull request into the vega-lite templates. Before this PR, the templates relied on a `rev` field that concatenated a bunch of internal DVC data (revision, filename, field name). This utilizes individual `dvc_...` fields to be able to use that data granularly in the templates.