### PR TITLE
move confusion matrix text to tooltip

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -267,6 +267,7 @@ class ConfusionTemplate(Template):
                         "tooltip": [
                             {"field": Template.anchor("x"), "type": "nominal"},
                             {"field": Template.anchor("y"), "type": "nominal"},
+                            {"field": "xy_count", "type": "quantitative"},
                         ],
                         "opacity": {
                             "condition": {"selection": "label", "value": 1},
@@ -283,7 +284,6 @@ class ConfusionTemplate(Template):
                 {
                     "mark": "text",
                     "encoding": {
-                        "text": {"field": "xy_count", "type": "quantitative"},
                         "color": {
                             "condition": {
                                 "test": "datum.percent_of_max > 0.5",
@@ -377,6 +377,11 @@ class NormalizedConfusionTemplate(Template):
                         "tooltip": [
                             {"field": Template.anchor("x"), "type": "nominal"},
                             {"field": Template.anchor("y"), "type": "nominal"},
+                            {
+                                "field": "percent_of_y",
+                                "type": "quantitative",
+                                "format": ".2f",
+                            },
                         ],
                         "opacity": {
                             "condition": {"selection": "label", "value": 1},
@@ -393,11 +398,6 @@ class NormalizedConfusionTemplate(Template):
                 {
                     "mark": "text",
                     "encoding": {
-                        "text": {
-                            "field": "percent_of_y",
-                            "type": "quantitative",
-                            "format": ".2f",
-                        },
                         "color": {
                             "condition": {
                                 "test": "datum.percent_of_y > 0.5",


### PR DESCRIPTION
Related to https://iterativeai.slack.com/archives/C01SR9Q12LB/p1681991760838949?thread_ts=1681958116.002649&cid=C01SR9Q12LB

Before: 
<img width="774" alt="Screenshot 2023-04-20 at 8 04 36 AM" src="https://user-images.githubusercontent.com/2308172/233360946-75b29990-770a-4151-aa26-06ba2cf0d80c.png">

After: 
<img width="732" alt="Screenshot 2023-04-20 at 8 02 57 AM" src="https://user-images.githubusercontent.com/2308172/233360990-5b2e226c-7624-4a88-a4e0-d5ba1d488dc5.png">

Doesn't necessarily look better for this example, but generally I think it will work better to have the values in the tooltip for anything beyond binary classification.