### PR TITLE
table: show nested metrics as separate columns

### DIFF
--- a/src/dvc_render/utils.py
+++ b/src/dvc_render/utils.py
@@ -1,5 +1,21 @@
+from collections.abc import MutableMapping
+
+
 def list_dict_to_dict_list(list_dict):
     """Convert from list of dictionaries to dictionary of lists."""
     if not list_dict:
         return {}
-    return {k: [x[k] for x in list_dict] for k in list_dict[0]}
+    flat_list_dict = [flatten(d) for d in list_dict]
+    return {k: [x[k] for x in flat_list_dict] for k in flat_list_dict[0]}
+
+
+# https://stackoverflow.com/questions/6027558/flatten-nested-dictionaries-compressing-keys
+def flatten(d, parent_key="", sep="."):
+    items = []
+    for k, v in d.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, MutableMapping):
+            items.extend(flatten(v, new_key, sep=sep).items())
+        else:
+            items.append((new_key, v))
+    return dict(items)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -24,3 +24,11 @@ def test_generate_markdown():
     assert "|   foo |   bar |" in md
     assert "|-------|-------|" in md
     assert "|     1 |     2 |" in md
+
+
+def test_nested():
+    datapoints = [{"foo": {"bar": 1}}]
+    html = TableRenderer(datapoints, "metrics.json").generate_html()
+    assert "<p>metrics_json</p>" in html
+    assert '<tr><th style="text-align: right;">  foo.bar</th></tr>' in html
+    assert '<tr><td style="text-align: right;">        1</td></tr>' in html


### PR DESCRIPTION
Before:

metrics.json

| train                        |   epoch |   step |
|------------------------------|---------|--------|
| {'loss': 0.0609191469848156} |       4 |    999 |

After:

metrics.json

|   train.loss |   epoch |   step |
|--------------|---------|--------|
|    0.0579433 |       4 |    999 |
