### PR TITLE
vega: Fix custom templates when `data` is not the first dict in the t…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ tests =
     %(markdown)s
     funcy>=1.17
     pytest==7.2.0
-    pytest-sugar==0.9.5
+    pytest-sugar>=0.9.6,<1.0
     pytest-cov==3.0.0
     pytest-mock==3.8.2
     pylint==2.15.0

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -64,7 +64,8 @@ def list_replace_value(l: list, name: str, value: str) -> list:  # noqa: E741
 def dict_find_value(d: dict, value: str) -> bool:
     for v in d.values():
         if isinstance(v, dict):
-            return dict_find_value(v, value)
+            if dict_find_value(v, value):
+                return True
         if isinstance(v, str):
             if v == value:
                 return True


### PR DESCRIPTION
…emplate.

The `has_anchor` check was returning at the first dictionary encounter so even if the template had a valid `data` anchor, it would fail if it was not the first dictionary.