### PR TITLE
allow for data anchor to be found in list

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -68,6 +68,8 @@ def dict_find_value(d: dict, value: str) -> bool:
         if isinstance(v, str):
             if v == value:
                 return True
+        if isinstance(v, list):
+            return any(dict_find_value(e, value) for e in v)
     return False
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -10,6 +10,7 @@ from dvc_render.vega_templates import (
     Template,
     TemplateContentDoesNotMatch,
     TemplateNotFoundError,
+    dict_find_value,
     dump_templates,
     get_template,
 )
@@ -101,3 +102,15 @@ def test_raise_on_init_modified(tmp_dir):
 def test_escape_special_characters():
     value = "foo.bar[2]"
     assert Template.escape_special_characters(value) == "foo\\.bar\\[2\\]"
+
+
+@pytest.mark.parametrize(
+    "content_dict, value_name",
+    [
+        ({"key": "value"}, "value"),
+        ({"key": {"subkey": "value"}}, "value"),
+        ({"key": [{"subkey": "value"}]}, "value"),
+    ],
+)
+def test_dict_find_value(content_dict, value_name):
+    assert dict_find_value(content_dict, value_name)


### PR DESCRIPTION
Before this PR, if I include the `<DVC_METRIC_DATA>` anchor in a custom template within a list, I would get this:

```
$ dvc plots show
ERROR: unexpected error - Template 'vega_linear.json' is not using '<DVC_METRIC_DATA>' anchor
```

Found this when trying out a vega (not vega-lite) template. Even though we don't support vega, it still seems like a bug, and vega actually works after this PR, at least for the [simple example](https://github.com/dberenbaum/vscode-dvc-demo/blob/vega/vega_linear.json) I tried.