### PR TITLE
Modified recursive dictionary parsing to correctly handle lists in dvc plot templates

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -61,16 +61,21 @@ def list_replace_value(l: list, name: str, value: str) -> list:  # noqa: E741
     return x
 
 
-def dict_find_value(d: dict, value: str) -> bool:
-    for v in d.values():
-        if isinstance(v, dict):
-            if dict_find_value(v, value):
-                return True
-        if isinstance(v, str):
-            if v == value:
-                return True
-        if isinstance(v, list):
-            return any(dict_find_value(e, value) for e in v)
+def dict_find_value(d: Union[dict, str], value: str) -> bool:
+    if isinstance(d, dict):
+        for v in d.values():
+            if isinstance(v, dict):
+                if dict_find_value(v, value):
+                    return True
+            if isinstance(v, str):
+                if v == value:
+                    return True
+            if isinstance(v, list):
+                if any(dict_find_value(e, value) for e in v):
+                    return True
+    elif isinstance(d, str):
+        if d == value:
+            return True
     return False
 
 

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -61,17 +61,17 @@ def list_replace_value(l: list, name: str, value: str) -> list:  # noqa: E741
     return x
 
 
-def dict_find_value(d: Union[dict, str], value: str) -> bool:
+def find_value(d: Union[dict, str], value: str) -> bool:
     if isinstance(d, dict):
         for v in d.values():
             if isinstance(v, dict):
-                if dict_find_value(v, value):
+                if find_value(v, value):
                     return True
             if isinstance(v, str):
                 if v == value:
                     return True
             if isinstance(v, list):
-                if any(dict_find_value(e, value) for e in v):
+                if any(find_value(e, value) for e in v):
                     return True
     elif isinstance(d, str):
         if d == value:
@@ -125,7 +125,7 @@ class Template:
 
     def has_anchor(self, name) -> bool:
         "Check if ANCHOR formatted with name is in content."
-        found = dict_find_value(self.content, self.anchor(name))
+        found = find_value(self.content, self.anchor(name))
         return found
 
     def fill_anchor(self, name, value) -> None:

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -61,7 +61,7 @@ def list_replace_value(l: list, name: str, value: str) -> list:  # noqa: E741
     return x
 
 
-def find_value(d: Union[dict, str], value: str) -> bool:
+def find_value(d: Union[dict, list, str], value: str) -> bool:
     if isinstance(d, dict):
         for v in d.values():
             if isinstance(v, dict):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -10,8 +10,8 @@ from dvc_render.vega_templates import (
     Template,
     TemplateContentDoesNotMatch,
     TemplateNotFoundError,
-    dict_find_value,
     dump_templates,
+    find_value,
     get_template,
 )
 
@@ -110,7 +110,8 @@ def test_escape_special_characters():
         ({"key": "value"}, "value"),
         ({"key": {"subkey": "value"}}, "value"),
         ({"key": [{"subkey": "value"}]}, "value"),
+        ({"key1": [{"subkey": "foo"}], "key2": {"subkey2": "value"}}, "value"),
     ],
 )
-def test_dict_find_value(content_dict, value_name):
-    assert dict_find_value(content_dict, value_name)
+def test_find_value(content_dict, value_name):
+    assert find_value(content_dict, value_name)


### PR DESCRIPTION
Previously, the way in which lists were parsed from dvc templates caused the `dict_find_value` function to end early without continuing to parse the rest of the template once it encountered a list. Additionally, the structure of vega-lite plots when using lists allows for the case of a list of strings. Because of this, when called recursively as was done in https://github.com/iterative/dvc-render/commit/635eaff2784f84302f9d354f763276740da246f3 , the function may fail when it encounters something like a list of strings, as it tries to access the values of d, which is no longer a dictionary, but a string. I have fixed this by allowing for `d` to be a string, but this may not be desired/sensible since the function is called `dict_find_value`. It may make sense to change the name of the function or to call another function to handle the string case.

I include a template which previously would not parse as reference for the changes made.

```json
{
    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
    "repeat": ["quintile"],
    "config": {"view": {"stroke": "transparent"}},
    "spec": {
        "title": {"text": "<DVC_METRIC_TITLE>", "anchor": "middle"},
        "encoding": {
            "column": {"field": "category", "header": {"orient": "bottom"}},
            "row": {"field": "quintile", "title": "Quintile"},
            "y": {"field": "<DVC_METRIC_Y>", "type": "quantitative"},
            "x": {"field": "<DVC_METRIC_X>", "axis": null},
            "color": {"field": "<DVC_METRIC_X>"}
            },
        "mark": "bar",
        "data": {
            "values": "<DVC_METRIC_DATA>"
        }
    }
}
```