### PR TITLE
Update default templates

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -143,6 +143,7 @@ class BarHorizontalSortedTemplate(Template):
         "width": 300,
         "height": 300,
         "mark": {"type": "bar"},
+        "params": [{"bind": "scales", "name": "grid", "select": "interval"}],
         "encoding": {
             "x": {
                 "field": Template.anchor("x"),
@@ -175,6 +176,7 @@ class BarHorizontalTemplate(Template):
         "width": 300,
         "height": 300,
         "mark": {"type": "bar"},
+        "params": [{"bind": "scales", "name": "grid", "select": "interval"}],
         "encoding": {
             "x": {
                 "field": Template.anchor("x"),
@@ -541,6 +543,7 @@ class SmoothLinearTemplate(Template):
                 ],
             },
             {
+                "params": [{"bind": "scales", "name": "grid", "select": "interval"}],
                 "mark": {"type": "line", "opacity": 0.2},
                 "encoding": {
                     "x": {
@@ -633,6 +636,7 @@ class SimpleLinearTemplate(Template):
             "type": "line",
             "tooltip": {"content": "data"},
         },
+        "params": [{"bind": "scales", "name": "grid", "select": "interval"}],
         "encoding": {
             "x": {
                 "field": Template.anchor("x"),

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -502,15 +502,17 @@ class SmoothLinearTemplate(Template):
                 },
             },
         ],
+        "encoding": {
+            "x": {
+                "field": Template.anchor("x"),
+                "type": "quantitative",
+                "title": Template.anchor("x_label"),
+            },
+        },
         "layer": [
             {
                 "mark": "line",
                 "encoding": {
-                    "x": {
-                        "field": Template.anchor("x"),
-                        "type": "quantitative",
-                        "title": Template.anchor("x_label"),
-                    },
                     "y": {
                         "field": Template.anchor("y"),
                         "type": "quantitative",
@@ -521,19 +523,14 @@ class SmoothLinearTemplate(Template):
                         "field": "rev",
                         "type": "nominal",
                     },
-                    "tooltip": [
-                        {
-                            "field": Template.anchor("x"),
-                            "title": Template.anchor("x_label"),
-                            "type": "quantitative",
-                        },
-                        {
-                            "field": Template.anchor("y"),
-                            "title": Template.anchor("y_label"),
-                            "type": "quantitative",
-                        },
-                    ],
                 },
+                "layer": [
+                    {"mark": "line"},
+                    {
+                        "transform": [{"filter": {"param": "hover", "empty": False}}],
+                        "mark": "point",
+                    },
+                ],
                 "transform": [
                     {
                         "loess": Template.anchor("y"),
@@ -558,18 +555,6 @@ class SmoothLinearTemplate(Template):
                         "scale": {"zero": False},
                     },
                     "color": {"field": "rev", "type": "nominal"},
-                    "tooltip": [
-                        {
-                            "field": Template.anchor("x"),
-                            "title": Template.anchor("x_label"),
-                            "type": "quantitative",
-                        },
-                        {
-                            "field": Template.anchor("y"),
-                            "title": Template.anchor("y_label"),
-                            "type": "quantitative",
-                        },
-                    ],
                 },
             },
             {
@@ -594,6 +579,38 @@ class SmoothLinearTemplate(Template):
                     },
                     "color": {"field": "rev", "type": "nominal"},
                 },
+            },
+            {
+                "transform": [
+                    {
+                        "calculate": "datum.rev + '::' + datum.filename + '::' + datum.field",  # noqa: E501
+                        "as": "tooltip_group",
+                    },
+                    {
+                        "pivot": "tooltip_group",
+                        "value": Template.anchor("y"),
+                        "groupby": [Template.anchor("x")],
+                    },
+                ],
+                "mark": {"type": "rule", "tooltip": {"content": "data"}},
+                "encoding": {
+                    "opacity": {
+                        "condition": {"value": 0.3, "param": "hover", "empty": False},
+                        "value": 0,
+                    }
+                },
+                "params": [
+                    {
+                        "name": "hover",
+                        "select": {
+                            "type": "point",
+                            "fields": [Template.anchor("x")],
+                            "nearest": True,
+                            "on": "mouseover",
+                            "clear": "mouseout",
+                        },
+                    }
+                ],
             },
         ],
     }

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -44,7 +44,7 @@ def test_default_template_mark():
 
     plot_content = VegaRenderer(datapoints, "foo").get_filled_template(as_string=False)
 
-    assert plot_content["layer"][0]["mark"] == "line"
+    assert plot_content["layer"][0]["layer"][0]["mark"] == "line"
 
     assert plot_content["layer"][1]["mark"] == {"type": "line", "opacity": 0.2}
 
@@ -78,7 +78,7 @@ def test_choose_axes():
             "second_val": 300,
         },
     ]
-    assert plot_content["layer"][0]["encoding"]["x"]["field"] == "first_val"
+    assert plot_content["encoding"]["x"]["field"] == "first_val"
     assert plot_content["layer"][0]["encoding"]["y"]["field"] == "second_val"
 
 


### PR DESCRIPTION
This PR adds zoom and pan functionality to the `bar_horizontal`, `bar_horizontal_sorted`, `smooth`, `linear` and `simple` templates. It also updates the `smooth`/`linear` plot's tooltips.

