### PR TITLE
Order image per step plots

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,7 +1,17 @@
 # pylint: disable=missing-function-docstring, R0801
+import os
+
 import pytest
 
-from dvc_render.html import HTML, PAGE_HTML, MissingPlaceholderError, render_html
+from dvc_render.html import (
+    HTML,
+    PAGE_HTML,
+    MissingPlaceholderError,
+    _order_image_per_step,
+    render_html,
+)
+from dvc_render.image import ImageRenderer
+from dvc_render.vega import VegaRenderer
 
 CUSTOM_PAGE_HTML = """<!DOCTYPE html>
 <html>
@@ -81,6 +91,45 @@ def test_render_html_with_custom_template(mocker, tmp_dir):
     custom_template.write_text(CUSTOM_PAGE_HTML)
     render_html(mocker.MagicMock(), output_file, custom_template)
     assert output_file.read_text() == CUSTOM_PAGE_HTML.format(plot_divs="")
+
+
+def test_order_image_per_step():
+    image_per_step_dir = "dvclive"
+    other_image_dir = "static"
+
+    def create_renderer(filename: str) -> ImageRenderer:
+        return ImageRenderer(
+            [
+                {
+                    "filename": filename,
+                    "rev": "workspace",
+                    "src": filename,
+                }
+            ],
+            filename,
+        )
+
+    r1 = VegaRenderer([], "dvc.yaml::Loss")
+    r2 = VegaRenderer([], "dvc.yaml::Accuracy")
+    r3 = create_renderer(os.path.join(image_per_step_dir, "0.jpg"))
+    r4 = create_renderer(os.path.join(image_per_step_dir, "1.jpg"))
+    r5 = create_renderer(os.path.join(image_per_step_dir, "2.jpg"))
+    r6 = create_renderer(os.path.join(image_per_step_dir, "10.jpg"))
+    r7 = create_renderer(os.path.join(other_image_dir, "a_file.jpg"))
+    r8 = create_renderer(os.path.join(other_image_dir, "z_file.jpg"))
+
+    renderers = [r7, r3, r5, r8, r1, r6, r4, r2]
+
+    assert sorted(renderers, key=_order_image_per_step) == [
+        r1,
+        r2,
+        r3,
+        r4,
+        r5,
+        r6,
+        r7,
+        r8,
+    ]
 
 
 def test_no_placeholder():


### PR DESCRIPTION
Discovered this one whilst working on https://github.com/iterative/dvc/issues/9940

This PR fixes a bug in the HTML. Previously "image per step" images where not ordered correctly due to their paths being treated as strings.

### Before

https://github.com/iterative/dvc-render/assets/37993418/ee7ba131-16df-43fb-a000-b214c09075d0

### After

https://github.com/iterative/dvc-render/assets/37993418/0a4335f8-d515-4082-a7a6-9ad1cc5df1bc

Note: don't ask for a slider.