### PR TITLE
toggle confusion matrix text

### DIFF
--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -207,7 +207,7 @@ class ConfusionTemplate(Template):
         "facet": {"field": "rev", "type": "nominal"},
         "params": [
             {
-                "name": "toggleText",
+                "name": "showValues",
                 "bind": {"input": "checkbox"},
             },
         ],
@@ -302,7 +302,7 @@ class ConfusionTemplate(Template):
                     "encoding": {
                         "text": {
                             "condition": {
-                                "param": "toggleText",
+                                "param": "showValues",
                                 "field": "xy_count",
                                 "type": "quantitative",
                             },

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -205,6 +205,12 @@ class ConfusionTemplate(Template):
         "data": {"values": Template.anchor("data")},
         "title": Template.anchor("title"),
         "facet": {"field": "rev", "type": "nominal"},
+        "params": [
+            {
+                "name": "toggleText",
+                "bind": {"input": "checkbox"},
+            },
+        ],
         "spec": {
             "transform": [
                 {
@@ -294,6 +300,13 @@ class ConfusionTemplate(Template):
                 {
                     "mark": "text",
                     "encoding": {
+                        "text": {
+                            "condition": {
+                                "param": "toggleText",
+                                "field": "xy_count",
+                                "type": "quantitative",
+                            },
+                        },
                         "color": {
                             "condition": {
                                 "test": "datum.percent_of_max > 0.5",


### PR DESCRIPTION
Closes:
* https://github.com/iterative/vscode-dvc/issues/4670
* https://github.com/iterative/dvc.org/issues/4866

After looking into this briefly, it was less work and more useful to add a toggle to turn text on or off.

Demo:

https://github.com/iterative/dvc-render/assets/2308172/d2cf7056-9519-4a06-8aea-6fba98a33df7

