### PR TITLE
Groupby mean

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.codespell]
-ignore-words-list = " "
+ignore-words-list = "fpr"
 
 [tool.ruff]
 ignore = [

--- a/src/dvc_render/vega_templates.py
+++ b/src/dvc_render/vega_templates.py
@@ -594,6 +594,7 @@ class SmoothLinearTemplate(Template):
                     {"calculate": Template.anchor("pivot_field"), "as": "pivot_field"},
                     {
                         "pivot": "pivot_field",
+                        "op": "mean",
                         "value": Template.anchor("y"),
                         "groupby": [Template.anchor("x")],
                     },

--- a/tests/test_vega.py
+++ b/tests/test_vega.py
@@ -604,6 +604,46 @@ def test_no_revs_with_datapoints():
     }
 
 
+# https://github.com/iterative/studio/issues/8851
+def test_linear_tooltip_groupby():
+    datapoints = [
+        {
+            "filename": "roc.json",
+            "fpr": 0.00399400898652022,
+            "tpr": 0.193158953722334,
+            "rev": "main",
+            "threshold": 0.84,
+        },
+        {
+            "filename": "roc.json",
+            "fpr": 0.00399400898652022,
+            "tpr": 0.2012072434607646,
+            "rev": "main",
+            "threshold": 0.829854797979798,
+        },
+        {
+            "filename": "roc.json",
+            "fpr": 0.00399400898652022,
+            "tpr": 0.20724346076458752,
+            "rev": "main",
+            "threshold": 0.8266666666666667,
+        },
+    ]
+
+    props = {
+        "anchors_y_definitions": [{"filename": "test", "field": "fpr"}],
+        "revs_with_datapoints": ["main"],
+        "template": "linear",
+        "x": "fpr",
+        "y": "tpr",
+    }
+
+    renderer = VegaRenderer(datapoints, "foo", **props)
+    plot_content = renderer.get_filled_template()
+
+    assert plot_content["layer"][3]["transform"][1]["op"] == "mean"
+
+
 @pytest.mark.parametrize(
     (
         "anchors_y_definitions",


### PR DESCRIPTION
See https://github.com/iterative/studio/issues/8851

Averages over groupby instead of summing, so that if there are multiple values within each group, we don't end up with unexpectedly large values (for example, >1 values in an ROC plot).

Before this PR:

https://github.com/iterative/dvc-render/assets/2308172/40426951-4508-4029-b966-538afcadfb0a

After this PR:

https://github.com/iterative/dvc-render/assets/2308172/58dcc517-b27f-412b-9fa5-375b3c6008a2

