### PR TITLE
drop safety

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
           pip --version
           nox --version
 
-      - name: Lint code and check dependencies
-        run: nox -s lint safety
+      - name: Lint code
+        run: nox -s lint
 
       - name: Run tests
         run: nox -s tests-${{ matrix.nox_pyv || matrix.pyv }} -- --cov-report=xml

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,14 +39,6 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session
-def safety(session: nox.Session) -> None:
-    """Scan dependencies for insecure packages."""
-    session.install(".[dev]")
-    session.install("safety")
-    session.run("safety", "check", "--full-report")
-
-
-@nox.session
 def build(session: nox.Session) -> None:
     session.install("build", "setuptools", "twine")
     session.run("python", "-m", "build")


### PR DESCRIPTION
GitHub has dependency alerts and dependency security updates that can replace `safety`.

For the past few months, safety has been raising vulnerability errors for `pip` and now `jinja2`. The latter is a dependency of `safety` itself, and both CVEs are disputed.

Which is breaking CI for us.